### PR TITLE
Instructions to add the ggc_user to the docker group

### DIFF
--- a/doc_source/run-docker-container.md
+++ b/doc_source/run-docker-container.md
@@ -14,7 +14,7 @@ You can store Docker images in Amazon S3 to provide them as component artifacts\
 To run a Docker container in a component, you need the following:
 + A Greengrass core device\. If you don't have one, see [Getting started with AWS IoT Greengrass V2](getting-started.md)\.
 + [Docker Engine](https://docs.docker.com/engine/) installed on your Greengrass core device\.
-+ [Docker configured for you to run it as a non\-root user](https://docs.docker.com/engine/install/linux-postinstall/)\. This lets you call `docker` commands without `sudo`\.
++ [Docker configured for you to run it as a non\-root user](https://docs.docker.com/engine/install/linux-postinstall/)\. This lets you call `docker` commands without `sudo`\.  To add the `ggc_user` to the `docker` group, run: `usermod -aG docker ggc_user`.
 + To use interprocess communication \(IPC\) in a Docker container component, you must set AWS IoT Greengrass Core environment variables in the Docker container\. For more information, see [Use interprocess communication in Docker container components](#docker-container-ipc)\.
 
 ## Run a Docker container from an image in Amazon S3<a name="s3-docker-image"></a>


### PR DESCRIPTION
I believe this change might be necessary in order to avoid this error:

```
2021-01-01T16:00:30.106Z [WARN] (Copier) com.example.MyDockerComponent: stderr. Got permission denied while trying to connect to the Docker daemon socket at unix:///var/run/docker.sock: Post http://%2Fvar%2Frun%2Fdocker.sock/v1.24/images/load?quiet=1: dial unix /var/run/docker.sock: connect: permission denied. {scriptName=services.com.example.MyDockerComponent.lifecycle.Install.Script, serviceName=com.example.MyDockerComponent, currentState=NEW}
```

After doing the change, I was able to successfully get a docker component running based on [these instructions](https://docs.aws.amazon.com/greengrass/v2/developerguide/run-docker-container.html)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
