### PR TITLE
Add user managent commands to list of requiterments

### DIFF
--- a/doc_source/setting-up.md
+++ b/doc_source/setting-up.md
@@ -51,6 +51,8 @@ You can use AWS IoT Device Tester for AWS IoT Greengrass to verify that the AWS 
 + Your device may also require the following optional shell commands:
   + \(Optional\) `systemctl` \(to set up the AWS IoT Greengrass Core software as a system service\)
   + \(Optional\) `mkfifo` \(to run Lambda functions as components\)
+  + \(Optional\) `useradd` and `groupadd` to setup the `ggc_user` and `ggc_group` on install
+  + \(Optional\) `id` and `usermod` to verify `ggc_user` and `ggc_group` on startup
 + To run Lambda functions, your device must meet additional requirements\. For more information, see [Requirements to run Lambda functions](#greengrass-v2-lambda-requirements)\.
 
 ### Requirements to run Lambda functions<a name="greengrass-v2-lambda-requirements"></a>


### PR DESCRIPTION
*Description of changes:*
If green grass is configured to run as the default ggc_user it will create if it does not exist on start up. To do this it calls out to shell commands, which this commit adds to the list of requirements.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
