### PR TITLE
Typo: greengrass -> greengrassv2

### DIFF
--- a/doc_source/device-status.md
+++ b/doc_source/device-status.md
@@ -33,7 +33,7 @@ You can check the status of a group of core devices \(a thing group\)\.
 + Run the following command to retrieve the status of multiple core devices\. Replace the ARN in the command with the ARN of the thing group to query\.
 
   ```
-  aws greengrass list-core-devices \
+  aws greengrassv2 list-core-devices \
     --thing-group-arn "arn:aws:iot:region:account-id:thinggroup/thingGroupName"
   ```
 


### PR DESCRIPTION
Refer to correct resource type.

*Issue #, if available:*

*Description of changes:*

Fixes small typo in the docs

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
