### PR TITLE
Add license information

### DIFF
--- a/doc_source/public-components.md
+++ b/doc_source/public-components.md
@@ -5,6 +5,8 @@ AWS IoT Greengrass provides and maintains public components that you can deploy 
 **Note**  
 Several public components depend on specific minor versions of the Greengrass nucleus\. Because of this dependency, you need to update these public components when you update the Greengrass nucleus to a new minor version\. For information about the specific versions of the nucleus that each component depends on, see the corresponding component topic\. For more information about updating the nucleus, see [Update the AWS IoT Greengrass Core software \(OTA\)](update-greengrass-core-v2.md)\.
 
+The license for each open source component can be [found in the respective GitHub repository](https://github.com/search?q=org%3Aaws-greengrass++filename%3ALICENSE&type=Repositories&ref=advsearch&l=&l=), all other components are subject to the [AWS Greengrass Core Software License](https://s3-us-west-2.amazonaws.com/greengrass-release-license/greengrass-license-v1.pdf
+
 
 | Component | Description | Depends on nucleus | Open source | 
 | --- | --- | --- | --- | 

--- a/doc_source/public-components.md
+++ b/doc_source/public-components.md
@@ -5,7 +5,7 @@ AWS IoT Greengrass provides and maintains public components that you can deploy 
 **Note**  
 Several public components depend on specific minor versions of the Greengrass nucleus\. Because of this dependency, you need to update these public components when you update the Greengrass nucleus to a new minor version\. For information about the specific versions of the nucleus that each component depends on, see the corresponding component topic\. For more information about updating the nucleus, see [Update the AWS IoT Greengrass Core software \(OTA\)](update-greengrass-core-v2.md)\.
 
-The license for each open source component can be [found in the respective GitHub repository](https://github.com/search?q=org%3Aaws-greengrass++filename%3ALICENSE&type=Repositories&ref=advsearch&l=&l=), all other components are subject to the [AWS Greengrass Core Software License](https://s3-us-west-2.amazonaws.com/greengrass-release-license/greengrass-license-v1.pdf
+The license for each open source component can be [found in the respective GitHub repository](https://github.com/search?q=org%3Aaws-greengrass++filename%3ALICENSE&type=Repositories&ref=advsearch&l=&l=), your use of the AWS Greengrass Core and any other components not subject to an open source agreement is governed by the [AWS Greengrass Core Software License](https://s3-us-west-2.amazonaws.com/greengrass-release-license/greengrass-license-v1.pdf
 
 
 | Component | Description | Depends on nucleus | Open source | 


### PR DESCRIPTION
A prospective user should not have to trawl Github and the [AWS Service Terms](https://aws.amazon.com/service-terms/#55._AWS_Greengrass) in order to locate the license for each component.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
