### PR TITLE
Clarify subscription router subscription ids

### DIFF
--- a/doc_source/legacy-subscription-router-component.md
+++ b/doc_source/legacy-subscription-router-component.md
@@ -141,8 +141,8 @@ The following example specifies that the `com.example.HelloWorldLambda` Lambda f
 ```
 {
   "subscriptions": {
-    "Greengrass_HelloWorld_to_cloud": {
-      "id": "Greengrass_HelloWorld_to_cloud",
+    "Greengrass_HelloWorld_to_MessageRelay": {
+      "id": "Greengrass_HelloWorld_to_MessageRelay",
       "source": "component:com.example.HelloWorldLambda",
       "subject": "hello/world",
       "target": "component:com.example.MessageRelay"
@@ -196,8 +196,8 @@ The following example specifies that the `Greengrass_HelloWorld` function publis
 
 ```
 "subscriptions": {
-  "Greengrass_HelloWorld_to_cloud": {
-    "id": "Greengrass_HelloWorld_to_cloud",
+  "Greengrass_HelloWorld_to_MessageRelay": {
+    "id": "Greengrass_HelloWorld_to_MessageRelay",
     "source": "arn:aws:lambda:us-west-2:123456789012:function:Greengrass_HelloWorld:5",
     "subject": "hello/world",
     "target": "arn:aws:lambda:us-west-2:123456789012:function:Greengrass_MessageRelay:5"


### PR DESCRIPTION
*Description of changes:*

Update the subscription router subscription identifiers to match the intended target (cloud vs. Lambda function). It looks like they were copy-pasted and the previous identifiers are slightly confusing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
