### PR TITLE
fix: sudo missing for systemctl

### DIFF
--- a/doc_source/uninstall-greengrass-core-v2.md
+++ b/doc_source/uninstall-greengrass-core-v2.md
@@ -9,7 +9,7 @@ You can uninstall the AWS IoT Greengrass Core software to remove it from a devic
    ```
    sudo systemctl stop greengrass.service && sudo systemctl disable greengrass.service
    sudo rm /etc/systemd/system/greengrass.service
-   systemctl daemon-reload && systemctl reset-failed
+   sudo systemctl daemon-reload && sudo systemctl reset-failed
    ```
 
 1. Remove the root folder from the device\. Replace */greengrass/v2* with the path to the root folder\.


### PR DESCRIPTION
*Issue #, if available:* missing

*Description of changes:*
`systemctl daemon-reload && systemctl reset-failed` requires root permissions, therefore added `sudo` to the documentation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
