### PR TITLE
Make MyPermissivePolicy even more permissive

### DIFF
--- a/doc_source/client-device-auth-component.md
+++ b/doc_source/client-device-auth-component.md
@@ -243,15 +243,15 @@ The following example configuration specifies to allow client devices whose name
 ```
 
 **Example: Configuration merge update \(using a permissive policy\)**  
-The following example configuration specifies to allow client devices whose names start with `MyClientDevice` to connect and publish/subscribe on all topics\.  
+The following example configuration specifies to allow any client devices to connect and publish/subscribe on all topics\.  
 
 ```
 {
   "deviceGroups": {
     "formatVersion": "2021-03-05",
     "definitions": {
-      "MyDeviceGroup": {
-        "selectionRule": "thingName: MyClientDevice*",
+      "MyPermissiveDeviceGroup": {
+        "selectionRule": "thingName: *",
         "policyName": "MyPermissivePolicy"
       }
     },


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Made a demo policy that's supposed to be extremely permissive, more permissive. Instead of making the policy match "MyClientDevice*", have it match every client. This would've saved me a couple hours in debugging if I knew that the permissive policy wasn't fully permissive.

You still get the example of matching every client device that starts with "MyClientDevice" above in the doc, so I argue you don't lose any explanatory power, but make the docs simpler for those looking to just test.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
