### PR TITLE
Fix C++ example in interprocess-communication.md

### DIFF
--- a/doc_source/interprocess-communication.md
+++ b/doc_source/interprocess-communication.md
@@ -314,14 +314,26 @@ AWS IoT Greengrass doesn't currently support this feature on Windows core device
            exit(-1);
        }
        
+       String message("Hello, World!");
+       String topic("my/topic");
+       int timeout = 10;
+       
        // Use the IPC client to create an operation request.
+       PublishToTopicRequest request;
+       Vector<uint8_t> messageData({message.begin(), message.end()});
+       BinaryMessage binaryMessage;
+       binaryMessage.SetMessage(messageData);
+       PublishMessage publishMessage;
+       publishMessage.SetBinaryMessage(binaryMessage);
+       request.SetTopic(topic);
+       request.SetPublishMessage(publishMessage);
        
        // Activate the operation request.
-       auto activate = operation.Activate(request, nullptr);
+       auto activate = operation->Activate(request, nullptr);
        activate.wait();
    
        // Wait for Greengrass Core to respond to the request.
-       auto responseFuture = operation.GetResult();
+       auto responseFuture = operation->GetResult();
        if (responseFuture.wait_for(std::chrono::seconds(timeout)) == std::future_status::timeout) {
            std::cerr << "Operation timed out while waiting for response from Greengrass Core." << std::endl;
            exit(-1);


### PR DESCRIPTION
*Description of changes:*
The first C++ example on [this page](https://docs.aws.amazon.com/greengrass/v2/developerguide/interprocess-communication.html) does not compile as it is missing the declarations / initializations for some variables and does not account for the `operation` variable being wrapped in a shared pointer. This PR fixes those bugs so it now compiles and runs properly. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
